### PR TITLE
al_entity program sometime will crash when executing simulated's function of get device information .

### DIFF
--- a/src/linux/platform_interfaces.c
+++ b/src/linux/platform_interfaces.c
@@ -873,7 +873,7 @@ void createLocalInterfaces(void)
     for (i = 0; i < interfaces_nr; i++)
     {
         const char *interface_name = interfaces_list[i];
-        struct interfaceInfo m;
+        struct interfaceInfo m = {0};
         struct interface *interface;
         struct interfaceWifi *interface_wifi = NULL;
 


### PR DESCRIPTION
m variable should be initilized before calling _executeInterfaceStub(…. , STUB_TYPE_GET_INFO, &m) function, because maybe some function of getting device information will use the content to check whether this variable be used firstly. for example, this statement "if (NULL == m->neighbor_mac_addresses) ...." in _getInterfaceInfoFromSimulatedDevice() function.